### PR TITLE
Implemented multi-currency features (now with full support of per-currency pricing)

### DIFF
--- a/classes/class-currency-helper.php
+++ b/classes/class-currency-helper.php
@@ -34,7 +34,7 @@ class WooCommerce_Product_Fees_Currency_Helper {
    * @return array An array of currency codes.
    */
   public static function enabled_currencies() {
-    return apply_filters('wc_aelia_cs_enabled_currencies', array(get_option('woocommerce_currency')));
+    return apply_filters('wc_aelia_cs_enabled_currencies', array(self::shop_base_currency()));
   }
 
   /**

--- a/classes/class-currency-helper.php
+++ b/classes/class-currency-helper.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Helper class to allow 3rd party plugins to implement multi-currency
+ * capabilities. The class was designed to work with the Aelia Currency Switcher,
+ * but it's generic enough to be adapted to other solutions.
+ *
+ * @author Aelia <support@aelia.co>
+ * @link https://aelia.co
+ * @link https://aelia.co/shop/currency-switcher-woocommerce/
+ */
+class WooCommerce_Product_Fees_Currency_Helper {
+  // @var string Shop's base currency. Used for caching.
+  protected static $_base_currency;
+
+  /**
+   * Returns shop's base currency. This method implements some simple caching,
+   * to avoid calling get_option() too many times.
+   *
+   * @return string Shop's base currency.
+   */
+  protected static function shop_base_currency() {
+    if(empty(self::$_base_currency)) {
+      self::$_base_currency = get_option('woocommerce_currency');
+    }
+    return self::$_base_currency;
+  }
+
+  /**
+   * Returns the list of the currencies enabled in the Aelia Currency Switcher.
+   * If the Currency Switcher is not installed, or active, then the list will
+   * only contain the shop base currency.
+   *
+   * @return array An array of currency codes.
+   */
+  public static function enabled_currencies() {
+    return apply_filters('wc_aelia_cs_enabled_currencies', array(get_option('woocommerce_currency')));
+  }
+
+  /**
+   * Returns a product's base currency. A product's base currency is the point
+   * of reference to calculate other prices, and it can differ from shop's base
+   * currency.
+   * For example, if a shop's base currency is USD, a product's base currency
+   * can be EUR. In such case, product prices in other currencies can be
+   * calculated automatically, as long as the EUR one is entered.
+   *
+   * @param int product_id A product ID.
+   * @param string default_currency The default currency to use if the product
+   * doesn't have a base currency.
+   * @return string A currency code.
+   */
+  public static function get_product_base_currency($product_id, $default_currency = null) {
+    if(empty($default_currency)) {
+      $default_currency = self::shop_base_currency();
+    }
+    return apply_filters('wc_aelia_cs_product_base_currency', $default_currency, $product_id);
+  }
+
+  /**
+   * Advanced integration with WooCommerce Currency Switcher, developed by Aelia
+   * (http://aelia.co). This method can be used by any 3rd party plugin to
+   * return prices in the active currency. The method allows to specify prices
+   * explicitly, thus bypassing automatic FX conversion.
+   *
+   * @param double price The source price.
+   * @param array prices_per_currency An optional array of currency => value
+   * pairs. If an entry is found in this array that matches the $to_currency
+   * parameters, such value is taken as is, and the automatic conversion logic
+   * is skipped.
+   * @param string to_currency The target currency. If empty, the active currency
+   * is taken.
+   * @param string from_currency The source currency. If empty, WooCommerce base
+   * currency is taken.
+   * @return double The price converted from source to destination currency.
+   */
+  public static function get_price_in_currency($price, array $prices_per_currency = array(), $to_currency = null, $from_currency = null) {
+    if(empty($from_currency)) {
+      $from_currency = self::shop_base_currency();
+    }
+    if(empty($to_currency)) {
+      $to_currency = get_woocommerce_currency();
+    }
+
+    // If an explicit price was passed for the target currency, just take it
+    if(!empty($prices_per_currency[$to_currency])) {
+      return $prices_per_currency[$to_currency];
+    }
+    return self::convert($price, $to_currency, $from_currency);
+  }
+
+  /**
+   * Converts an amount from one currency to another, using exchange rates.
+   *
+   * @param float amount The amount to convert.
+   * @param string to_currency The destination currency.
+   * @param string from_currency The source currency.
+   * @return float The amount converted to the target destination currency.
+   */
+  public static function convert($amount, $to_currency, $from_currency = null) {
+    return apply_filters('wc_aelia_cs_convert', $amount, $from_currency, $to_currency);
+  }
+}

--- a/classes/class-woocommerce-product-fees-admin.php
+++ b/classes/class-woocommerce-product-fees-admin.php
@@ -38,8 +38,7 @@ class Woocommerce_Product_Fees_Admin {
 	}
 
 	public function product_settings_fields() {
-
-		global $woocommerce;
+		global $woocommerce, $post;
 
 		echo '<div id="fees_product_data" class="fee_panel panel woocommerce_options_panel wc-metaboxes-wrapper">';
 		echo '<div class="options_group">';
@@ -47,9 +46,55 @@ class Woocommerce_Product_Fees_Admin {
 		// Text Field - Fee Name
 		woocommerce_wp_text_input( array( 'id' => 'product-fee-name', 'label' => __( 'Fee Name', 'woocommerce-product-fees' ), 'data_type' => 'text', 'placeholder' => __('Product Fee', 'placeholder', 'woocommerce-product-fees'), 'desc_tip' => 'true', 'description' => __( 'This will be shown at checkout descriping the added fee.', 'woocommerce-product-fees' ) ) );
 
-		// Text Field - Fee Amount
-		woocommerce_wp_text_input( array( 'id' => 'product-fee-amount', 'label' => __( 'Fee Amount', 'woocommerce-product-fees' ) . ' (' . get_woocommerce_currency_symbol() . ')', 'data_type' => 'price', 'desc_tip' => 'true', 'description' => __( 'Enter a monetary decimal without any currency symbols or thousand seperators. This field also accepts percentages.', 'woocommerce-product-fees' ) ) );
-		
+
+		// Load product's base currency. It will be used to show the Admin which
+		// fees can be calculated automatically
+		$product_base_currency = WooCommerce_Product_Fees_Currency_Helper::get_product_base_currency($post->ID);
+
+		// Get a list of the enabled currencies. We will need to display one price
+		// field for each. By using the merge/unique trick, we can make sure that
+		// product's base currency is always the first in the list (the enabled_currencies()
+		// method returns them sorted alphabetically)
+		$enabled_currencies = array_unique(array_merge(
+			array($product_base_currency),
+			WooCommerce_Product_Fees_Currency_Helper::enabled_currencies()
+		));
+
+		$placeholder = '';
+		foreach($enabled_currencies as $currency) {
+			$field_description = __( 'Enter a monetary decimal without any currency symbols or thousand separators. This field also accepts percentages.', 'woocommerce-product-fees' );
+			// For additional currencies, add an extra description to explain that the
+			// fees can be calculated automatically
+			if($currency != $product_base_currency) {
+				$field_description = ' ' . sprintf(
+					__( 'If you leave this field empty, its value will be calculated automatically, by converting the base amount in %s to this currency.', 'woocommerce-product-fees' ),
+					$product_base_currency
+				);
+			}
+
+			// If we have more than one currency, show a different placeholder for
+			// the base currency and the additional ones, to help the admin to understand
+			// which ones can be calculated automatically. When a single currency is
+			// used, the placeholder can be left empty, as the field's purpose is
+			// obvious
+			if(count($enabled_currencies) > 1) {
+				$placeholder = ($currency === $product_base_currency) ? __('Base amount', 'woocommerce-product-fees') : __('Auto', 'woocommerce-product-fees');
+			}
+
+			// Text Field - Fee Amount
+			woocommerce_wp_text_input( array(
+				'id' => 'product-fee-amount-' . $currency,
+				'label' => __( 'Fee Amount', 'woocommerce-product-fees' ) . ' (' . $currency . ')',
+				'data_type' => 'price',
+				'desc_tip' => 'true',
+				'description' => $field_description,
+				// The field must be set up as an array, so that we can get one value for
+				// each currency
+				'name' => 'product-fee-amount[' . $currency . ']',
+				'placeholder' => $placeholder,
+			));
+		}
+
 		echo '</div>';
 		echo '<div class="options_group">';
 
@@ -62,23 +107,26 @@ class Woocommerce_Product_Fees_Admin {
 	}
 
 	public function save_product_settings_fields( $post_id ){
-		
+
 		// Text Field - Fee Name
 		$product_fee_name_text_field = $_POST['product-fee-name'];
 		if( ! empty( $product_fee_name_text_field ) ) {
 			update_post_meta( $post_id, 'product-fee-name', esc_attr( $product_fee_name_text_field ) );
 		}
 
-		// Text Field - Fee Amount
-		$product_fee_amount_text_field = $_POST['product-fee-amount'];
-		if( ! empty( $product_fee_amount_text_field ) ) {
-			update_post_meta( $post_id, 'product-fee-amount', esc_attr( $product_fee_amount_text_field ) );
+		// Text Field - Fee Amounts in each currency
+		$product_fee_amounts = $_POST['product-fee-amount'];
+		if( ! empty( $product_fee_amounts ) ) {
+			// Save the fee amount for each currency
+			foreach($product_fee_amounts as $currency => $amount) {
+				update_post_meta( $post_id, 'product-fee-amount-' . $currency, esc_attr( $amount ) );
+			}
 		}
 
 		// Check Box - Fee Multiply Option
 		$product_fee_multiplier_checkbox = isset( $_POST['product-fee-multiplier'] ) ? 'yes' : 'no';
 	    update_post_meta( $post_id, 'product-fee-multiplier', $product_fee_multiplier_checkbox );
-			
+
 	}
 
 	public function admin_css() {

--- a/classes/class-woocommerce-product-fees.php
+++ b/classes/class-woocommerce-product-fees.php
@@ -15,6 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// Lod the helper class to handle multiple currencies
+require_once 'class-currency-helper.php';
+
 class Woocommerce_Product_Fees {
 
 	public function __construct() {
@@ -30,14 +33,14 @@ class Woocommerce_Product_Fees {
 		// Add the fee
 		add_action( 'woocommerce_cart_calculate_fees', array( $this, 'get_product_fee_data' ) );
 
-	} 
+	}
 
 	/**
 	 * Load Text Domain
 	 */
 	public function text_domain() {
 
-	 	load_plugin_textdomain( 'woocommerce-product-fees', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' ); 
+	 	load_plugin_textdomain( 'woocommerce-product-fees', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 
 	}
 
@@ -49,7 +52,7 @@ class Woocommerce_Product_Fees {
  		global $woocommerce;
 
   		$woocommerce->cart->add_fee( __($fee_name, 'woocommerce-product-fees'), $fee_amount );
-	
+
 	}
 
 	/**
@@ -115,14 +118,14 @@ class Woocommerce_Product_Fees {
 			if ( $cart_product->id == $product_id ) {
 
 				$new_product_fee = $this->quantity_multiply( $product_fee, $cart_product_price, $quantity_multiply, $cart_product_qty );
-			
+
 				// Send multiplied fee data to add_product_fee()
 				$this->add_product_fee( $new_product_fee, $product_fee_name );
 
 			}
-		
+
 		}
-		
+
 	}
 
 	/**
@@ -141,13 +144,17 @@ class Woocommerce_Product_Fees {
 
 				$fee_name = get_post_meta( $cart_product->id, 'product-fee-name', true );
 				$fee_amount = get_post_meta( $cart_product->id, 'product-fee-amount', true );
+
+				// Convert the fee to the active currency
+				$fee_amount = WooCommerce_Product_Fees_Currency_Helper::get_price_in_currency($fee_amount);
+
 				$fee_multiplier = get_post_meta( $cart_product->id, 'product-fee-multiplier', true );
 
 				// Send fee data to product_specific_fee()
 				$this->product_specific_fee( $cart_product->id, $fee_amount, $fee_name, $fee_multiplier );
 
 			}
-		
+
 		}
 
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: iCaleb
 Tags: woocommerce, woocommerce fees, woocommerce surcharge, product fees, product surcharge, additional fees, product based fees
 Requires at least: 4.0
 Tested up to: 4.3
-Stable tag: 2.4.5
+Stable tag: 1.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -71,6 +71,9 @@ Bugs can be reported either in our support forum or preferably on the [WooCommer
 2. Fees shown at checkout.
 
 == Changelog ==
+
+= 1.1 - 08/26/2015 =
+* Added full support for multiple currency setups.
 
 = 1.0 - 08/25/2015 =
 * Feature - Percentage based fees.

--- a/woocommerce-product-fees.php
+++ b/woocommerce-product-fees.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Product Fees
  * Plugin URI: http://calebburks.com/woocommerce-product-fees
  * Description: Add additional fees at checkout based on products that are in the cart.
- * Version: 1.0
+ * Version: 1.1
  * Author: Caleb Burks
  * Author URI: http://calebburks.com
  *


### PR DESCRIPTION
As per subject, I added initial support for multi-currency features. At this stage, the Product Fees plugin allows to enter one fee in base currency, and its amount will be converted automatically to the active currency when the product is added to the cart.
## Summary of changes
- Added helper class. The class has been adapted from our code examples, and I added a prefix to prevent clashes with other plugins.
- Added call to convert product fee to the active currency before applying it to the cart.
