### PR TITLE
Removing deprecated $woocommerce

### DIFF
--- a/classes/class-woocommerce-product-fees-admin.php
+++ b/classes/class-woocommerce-product-fees-admin.php
@@ -39,8 +39,6 @@ class Woocommerce_Product_Fees_Admin {
 
 	public function product_settings_fields() {
 
-		global $woocommerce;
-
 		echo '<div id="fees_product_data" class="fee_panel panel woocommerce_options_panel wc-metaboxes-wrapper">';
 		echo '<div class="options_group">';
 

--- a/classes/class-woocommerce-product-fees.php
+++ b/classes/class-woocommerce-product-fees.php
@@ -46,9 +46,7 @@ class Woocommerce_Product_Fees {
 	 */
 	public function add_product_fee( $fee_amount, $fee_name ) {
 
- 		global $woocommerce;
-
-  		$woocommerce->cart->add_fee( __($fee_name, 'woocommerce-product-fees'), $fee_amount );
+  		WC()->cart->add_fee( __($fee_name, 'woocommerce-product-fees'), $fee_amount );
 	
 	}
 
@@ -103,9 +101,7 @@ class Woocommerce_Product_Fees {
 	 */
 	public function product_specific_fee( $product_id, $product_fee, $product_fee_name, $quantity_multiply ) {
 
-		global $woocommerce;
-
-		foreach( $woocommerce->cart->get_cart() as $cart_item_key => $values ) {
+		foreach( WC()->cart->get_cart() as $cart_item_key => $values ) {
 
 			$cart_product = $values['data'];
 			$cart_product_qty = $values['quantity'];
@@ -130,9 +126,7 @@ class Woocommerce_Product_Fees {
 	 */
 	public function get_product_fee_data() {
 
-		global $woocommerce;
-
-		foreach( $woocommerce->cart->get_cart() as $cart_item_key => $values ) {
+		foreach( WC()->cart->get_cart() as $cart_item_key => $values ) {
 
 			$cart_product = $values['data'];
 


### PR DESCRIPTION
Removed `$woocommerce` in the code since it's deprecated and will be probably removed in WooCommerce soon or later. Using `WC()` instead.
