### PR TITLE
Removed inner loop from product_specific_fees

### DIFF
--- a/classes/class-woocommerce-product-fees.php
+++ b/classes/class-woocommerce-product-fees.php
@@ -110,24 +110,20 @@ class Woocommerce_Product_Fees {
 	/**
 	 * Checks if products in the cart have added fees. If so, then it sends the data to add_product_fee().
 	 */
-	public function product_specific_fee( $product_id, $product_fee, $product_fee_name, $quantity_multiply, $parent_variation_fee ) {
+	public function product_specific_fee( $values, $product_id, $product_fee, $product_fee_name, $quantity_multiply, $parent_variation_fee ) {
 
-		foreach( WC()->cart->get_cart() as $cart_item_key => $values ) {
+		$cart_product = $values['data'];
+		$cart_product_qty = $values['quantity'];
+		$cart_product_price = $cart_product->price;
 
-			$cart_product = $values['data'];
-			$cart_product_qty = $values['quantity'];
-			$cart_product_price = $cart_product->price;
+		// Checks if each product in the cart has additional fees that need to be added
+		if ( $cart_product->id == $product_id || $values['variation_id'] == $product_id ) {
 
-			// Checks if each product in the cart has additional fees that need to be added
-			if ( $cart_product->id == $product_id || $values['variation_id'] == $product_id ) {
+			$new_product_fee = $this->quantity_multiply( $product_fee, $cart_product_price, $quantity_multiply, $cart_product_qty );
 
-				$new_product_fee = $this->quantity_multiply( $product_fee, $cart_product_price, $quantity_multiply, $cart_product_qty );
+			// Send multiplied fee data to add_product_fee()
+			$this->add_product_fee( $new_product_fee, $product_fee_name, $parent_variation_fee );
 
-				// Send multiplied fee data to add_product_fee()
-				$this->add_product_fee( $new_product_fee, $product_fee_name, $parent_variation_fee );
-
-			}
-		
 		}
 		
 	}
@@ -171,7 +167,7 @@ class Woocommerce_Product_Fees {
 				$filtered_fee_data = apply_filters( 'woocommerce_product_fees_filter_fee_data',  $fee );
 
 				// Send fee data to product_specific_fee()
-				$this->product_specific_fee( $cart_product_id, $filtered_fee_data['amount'], $filtered_fee_data['name'], $filtered_fee_data['multiplier'], $parent_variation_fee );
+				$this->product_specific_fee( $values, $cart_product_id, $filtered_fee_data['amount'], $filtered_fee_data['name'], $filtered_fee_data['multiplier'], $parent_variation_fee );
 
 			}
 		


### PR DESCRIPTION
Right now the way fees are calculated there are 2 nested loops: one loop for getting the fee information and another loop for applying the fees.

It seems you only need one loop, one that gets the fee information for each product and then applies it to the current product (without looping over the cart again).

The nested loops are actually a problem when using certain plugins that cause the same product to be added to a cart as separate line items, e.g. when you are customizing the product with customer-supplied data, there would be several items with the same product ID but with different customizations.  This causes the fees to be the square of what they should be because the nested loop reapplies the fees for all items each time it encounters an item in the cart.

This can be fixed simply by just eliminating the inner loop in the product_specific_fee problem, as I did in this pull request.  I don't believe it breaks anything, unless there's a reason for the nested loop that I don't see. 
