### PR TITLE
WooCommerce 3.0+ compatibility

### DIFF
--- a/classes/admin/class-wcpf-admin-product-settings.php
+++ b/classes/admin/class-wcpf-admin-product-settings.php
@@ -18,7 +18,7 @@ class WCPF_Admin_Product_Settings {
 	public function __construct() {
 		// Add and save product settings.
 		add_action( 'woocommerce_product_write_panel_tabs', array( $this, 'create_product_panel_tab' ) );
-		add_action( 'woocommerce_product_write_panels', array( $this, 'product_settings_fields' ) );
+		add_action( 'woocommerce_product_data_panels', array( $this, 'product_settings_fields' ) );
 		add_action( 'woocommerce_process_product_meta', array( $this, 'save_product_settings_fields' ) );
 
 		// Add and save variation settings.

--- a/classes/class-woocommerce-product-fees.php
+++ b/classes/class-woocommerce-product-fees.php
@@ -61,12 +61,12 @@ class WooCommerce_Product_Fees {
 
 			if ( 0 !== $values['variation_id'] ) {
 				// Get variation fee. Will return false if there is no fee.
-				$fee = new WCPF_Variation_Fee( $values['product_id'], $values['quantity'], $values['data']->price, $values['variation_id'] );
+				$fee = new WCPF_Variation_Fee( $values['product_id'], $values['quantity'], $values['data']->get_price(), $values['variation_id'] );
 			}
 
 			if ( ! $fee ) {
 				// Get product fee. Will return false if there is no fee.
-				$fee = new WCPF_Product_Fee( $values['product_id'], $values['quantity'], $values['data']->price );
+				$fee = new WCPF_Product_Fee( $values['product_id'], $values['quantity'], $values['data']->get_price() );
 			}
 
 			if ( $fee->return_fee() ) {


### PR DESCRIPTION
Bumped into this: `woocommerce_product_write_panels is deprecated since version 2.6!`

PR also solves #24 

@WPprodigy 